### PR TITLE
chore(build-push.yml): add step to create image tags using docker/metadata-action

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -33,12 +33,23 @@ jobs:
       - id: extract_branch
         uses: swapActions/get-branch-name@v1
 
+      - name: Create image tags
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/userofficeproject/ror-gateway
+          flavor: latest=true # adds :latest tag to outputs.tags
+          tags: | # adds :<sha> tag to outputs.tags
+            type=sha,format=long,prefix=
+            type=raw,${{ steps.extract_branch.outputs.branch }}
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ghcr.io/userofficeproject/ror-gateway:${{ steps.extract_branch.outputs.branch }}
+          tags: ${{ steps.meta.outputs.tags }}
 
       - name: Trigger pipeline
         uses: swapActions/trigger-useroffice-deployment@v1


### PR DESCRIPTION

feat(build-push.yml): use created image tags in docker/build-push-action to tag the image with branch name and latest

The changes were made to the `.github/workflows/build-push.yml` file.

1. A new step was added to create image tags using the `docker/metadata-action`. This step generates tags for the image `ghcr.io/userofficeproject/ror-gateway` based on the branch name and commit SHA.

2. The `tags` parameter in the `docker/build-push-action` step was updated to use the created image tags. This ensures that the image is tagged with the branch name and the latest tag.

These changes were made to improve the tagging process for the Docker image and ensure that the correct tags are applied during the build and push process.
