### PR TITLE
chore(build-push.yml): update trigger action to use swapActions

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -52,9 +52,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Trigger pipeline
-        uses: swapActions/trigger-useroffice-deployment@v1
+        uses: swapActions/trigger-swap-deployment@v1
         with:
-          repository: ${{ github.repository }}
+          repository: ${{ github.event.repository.name }}
           environment: ${{ steps.extract_branch.outputs.branch }}
           gh-trigger-url: ${{ secrets.GITLAB_TRIGGER_URL }}
           gh-token: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
+          image-tag: ${{ github.sha }}


### PR DESCRIPTION
update trigger action to use swapActions/trigger-swap-deployment@v1 instead of swapActions/trigger-useroffice-deployment@v1

chore(build-push.yml): update repository parameter in trigger action to use ${{ github.event.repository.name }} instead of ${{ github.repository }}
chore(build-push.yml): add image-tag parameter to trigger action with value ${{ github.sha }} to ensure unique image tag for each build
