### PR TITLE
fix(organizations.ts): fix allow partial search

### DIFF
--- a/src/queries/organizations.ts
+++ b/src/queries/organizations.ts
@@ -14,7 +14,7 @@ export default async (req: Request<{}, {}, {}, SearchQuery>, res: Response) => {
     const response = await axios.get<{}, { data: { items: Organization[] } }>(
       `${ROR_BASE_URL}/organizations`,
       {
-        params: req.query,
+        params: { ...req.query, query: `${req.query.query}*` },
       }
     );
 


### PR DESCRIPTION
## Description
This PR enables users to search organizations from ROR by providing a partial organization name.
According to the documentation https://ror.readme.io/docs/advanced-query-parameter it is possible to get the desired behavior by using wildcard character at the end of query
